### PR TITLE
Feature/directory parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,3 +35,5 @@ module.exports = function extract(source, name = '') {
 
   return parseComment(parsed[0]);
 };
+
+module.exports.parseDirectory = require('./parse-directory');

--- a/index.js
+++ b/index.js
@@ -26,23 +26,12 @@ function parseComment(comment) {
   };
 }
 
-module.exports = function extract(source, actions = []) {
+module.exports = function extract(source, name = '') {
   const parsed = commentsParser(source.toString());
 
-  // Filter out docs that aren't actions
-  const docs = parsed.map(parseComment).filter((doc) => {
-    if (actions.length) {
-      return doc.name && actions.includes(doc.name);
-    }
-    return doc.name;
-  });
+  if (!parsed[0]) {
+    return { name };
+  }
 
-  // Add missing actions to docs
-  actions.forEach((action) => {
-    if (!docs.find(doc => doc.name === action)) {
-      docs.push({ name: action, description: '' });
-    }
-  });
-
-  return docs;
+  return parseComment(parsed[0]);
 };

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const parseDescription = require('./lib/description');
 const parseFullDescription = require('./lib/full-description');
 const parseParams = require('./lib/params');
 const parseThrows = require('./lib/throws');
+const buildErrors = require('./lib/errors');
 const parseReturns = require('./lib/returns');
 const parseSecrets = require('./lib/secrets');
 
@@ -13,12 +14,14 @@ function getTags(parsed, t) {
 }
 
 function parseComment(comment, name) {
+  const throws = parseThrows(getTags(comment, 'throws'));
   return {
     name,
     description: parseDescription(comment.lines[0]),
     fullDescription: parseFullDescription(comment.lines),
     params: parseParams(getTags(comment, 'param')),
-    throws: parseThrows(getTags(comment, 'throws')),
+    throws,
+    errors: buildErrors(throws),
     secrets: parseSecrets(getTags(comment, 'secret')),
     returns: parseReturns(getTags(comment, 'returns')),
   };

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const parseFullDescription = require('./lib/full-description');
 const parseParams = require('./lib/params');
 const parseThrows = require('./lib/throws');
 const parseReturns = require('./lib/returns');
-const parseName = require('./lib/name');
 const parseSecrets = require('./lib/secrets');
 
 function getTags(parsed, t) {
@@ -13,11 +12,10 @@ function getTags(parsed, t) {
     .map(p => p.value);
 }
 
-function parseComment(comment) {
-  const nameDescription = parseDescription(comment.lines[0]);
+function parseComment(comment, name) {
   return {
-    name: parseName(nameDescription.name, getTags(comment, 'name')),
-    description: nameDescription.description,
+    name,
+    description: parseDescription(comment.lines[0]),
     fullDescription: parseFullDescription(comment.lines),
     params: parseParams(getTags(comment, 'param')),
     throws: parseThrows(getTags(comment, 'throws')),
@@ -33,7 +31,7 @@ module.exports = function extract(source, name = '') {
     return { name };
   }
 
-  return parseComment(parsed[0]);
+  return parseComment(parsed[0], name);
 };
 
 module.exports.parseDirectory = require('./parse-directory');

--- a/lib/description.js
+++ b/lib/description.js
@@ -1,10 +1,3 @@
-// Matches:
-// name: description
-// name
-const NAME_IN_DESCRIPTION = /^(?:([\w]+):[\W]+)?([\w\W]+)/;
-
 module.exports = function parseDescription(description) {
-  const matches = description.match(NAME_IN_DESCRIPTION);
-  if (matches[1] === undefined) return { name: matches[2] };
-  return { name: matches[1], description: matches[2] };
+  return description;
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,24 @@
+const template = require('lodash.template');
+
+const interpolate = /\${([\s\S]+?)}/g;
+
+function Errors(throws) {
+  Object.assign(this, Object.keys(throws).reduce((errors, next) => {
+    const error = throws[next];
+    return Object.assign(errors, {
+      [error.type]: template(error.description, { interpolate }),
+    });
+  }, {}));
+}
+
+Errors.prototype.toString = function toString() {
+  return Object.keys(this).reduce((errors, next) => {
+    return Object.assign(errors, {
+      [next]: this[next].source,
+    });
+  }, {});
+};
+
+module.exports = (throws) => {
+  return new Errors(throws);
+};

--- a/lib/name.js
+++ b/lib/name.js
@@ -1,4 +1,0 @@
-module.exports = function parseName(name, nameTags) {
-  if (nameTags.length) return nameTags[0];
-  return name;
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -972,6 +972,11 @@
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
@@ -1010,6 +1015,23 @@
         "lodash._getnative": "3.9.1",
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "requires": {
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "comments-parser": "github:readmeio/node-comments-parser"
+    "comments-parser": "github:readmeio/node-comments-parser",
+    "lodash.template": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "eslint-config-airbnb-base": "^11.1.1",
     "eslint-plugin-import": "^2.2.0",
     "mocha": "^3.2.0",
-    "nyc": "^10.1.2"
+    "nyc": "^10.1.2",
+    "rimraf": "^2.6.1"
   },
   "dependencies": {
     "comments-parser": "github:readmeio/node-comments-parser"

--- a/parse-directory.js
+++ b/parse-directory.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
+const { basename } = require('path');
 
 const buildDocs = require('./');
 
 module.exports = (directory) => {
   return fs.readdirSync(directory)
     .filter(file => file.endsWith('.js'))
-    .map(file => buildDocs(fs.readFileSync(file, 'utf8')));
+    .map(file => buildDocs(fs.readFileSync(file, 'utf8'), basename(file, '.js')));
 };

--- a/parse-directory.js
+++ b/parse-directory.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+
+const buildDocs = require('./');
+
+module.exports = (directory) => {
+  return fs.readdirSync(directory)
+    .filter(file => file.endsWith('.js'))
+    .map(file => buildDocs(fs.readFileSync(file, 'utf8')));
+};

--- a/parse-directory.js
+++ b/parse-directory.js
@@ -1,10 +1,10 @@
 const fs = require('fs');
-const { basename } = require('path');
+const { basename, join } = require('path');
 
 const buildDocs = require('./');
 
 module.exports = (directory) => {
   return fs.readdirSync(directory)
     .filter(file => file.endsWith('.js'))
-    .map(file => buildDocs(fs.readFileSync(file, 'utf8'), basename(file, '.js')));
+    .map(file => buildDocs(fs.readFileSync(join(directory, file), 'utf8'), basename(file, '.js')));
 };

--- a/test/fixtures/createUser.js
+++ b/test/fixtures/createUser.js
@@ -1,5 +1,5 @@
 /*
- * createUser: Creates a user in the database
+ * Creates a user in the database
  *
  * Dolore dolore aute nisi est enim dolor cupidatat aute incididunt
  * sit commodo in sit eiusmod nostrud eu ea enim quis velit et sunt

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1,58 +1,38 @@
-[
-  {
-    "name": "createUser",
-    "description": "Creates a user in the database",
-    "fullDescription": "Dolore dolore aute nisi est enim dolor cupidatat aute incididunt sit commodo in sit eiusmod nostrud eu ea enim quis velit et sunt laborum et enim ut laboris non consequat in fugiat eu duis sint.",
-    "params": [
-      {
-        "title": "name",
-        "description": "Name of the user",
-        "exampleData": "Marc Cuva",
+{
+  "name": "createUser",
+  "description": "Creates a user in the database",
+  "fullDescription": "Dolore dolore aute nisi est enim dolor cupidatat aute incididunt sit commodo in sit eiusmod nostrud eu ea enim quis velit et sunt laborum et enim ut laboris non consequat in fugiat eu duis sint.",
+  "params": [
+    {
+      "title": "name",
+      "description": "Name of the user",
+      "exampleData": "Marc Cuva",
+      "type": "string"
+    },
+    {
+      "title": "age",
+      "description": "Age of the user",
+      "exampleData": 12,
+      "type": "number"
+    },
+    {
+      "title": "interests",
+      "description": "Interests of the user",
+      "type": "array",
+      "items": {
         "type": "string"
-      },
-      {
-        "title": "age",
-        "description": "Age of the user",
-        "exampleData": 12,
-        "type": "number"
-      },
-      {
-        "title": "interests",
-        "description": "Interests of the user",
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
       }
-    ],
-    "throws": [
-      {
-        "type": "ValidationError",
-        "description": "Must provide all required fields"
-      }
-    ],
-    "secrets": [],
-    "returns": {
-      "description": "The saved user",
-      "type": "object"
     }
-  },
-  {
-    "name": "deleteUser",
-    "description": "Deletes a user in the database",
-    "fullDescription": "",
-    "params": [
-      {
-        "title": "id",
-        "description": "Id of the user",
-        "type": "number"
-      }
-    ],
-    "throws": [],
-    "secrets": [],
-    "returns": {
-      "description": "Whether the deletion was successful",
-      "type": "boolean"
+  ],
+  "throws": [
+    {
+      "type": "ValidationError",
+      "description": "Must provide all required fields"
     }
+  ],
+  "secrets": [],
+  "returns": {
+    "description": "The saved user",
+    "type": "object"
   }
-]
+}

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -30,6 +30,7 @@
       "description": "Must provide all required fields"
     }
   ],
+  "errors": {},
   "secrets": [],
   "returns": {
     "description": "The saved user",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,11 +9,11 @@ describe('build-docs', () => {
     const description = 'Creates a user in the database';
     assert.deepEqual(docs(`
       /*
-       * name: ${description}
+       * ${description}
        */
 
       /*
-       * name2: ${description}
+       * ${description}
        */
     `).description, description);
   });
@@ -29,7 +29,7 @@ describe('build-docs', () => {
     const description = 'Creates a user in the database';
     const doc = docs(`
       /*
-       * ${name}: ${description}
+       * ${description}
        */
 
       // console.log('test')
@@ -44,7 +44,7 @@ describe('build-docs', () => {
       const description = 'Creates a user in the database';
       assert.deepEqual(docs(`
         /*
-         * name: ${description}
+         * ${description}
          */
       `).description, description);
     });
@@ -53,7 +53,7 @@ describe('build-docs', () => {
       const description = 'Creates a user in the database';
       assert.deepEqual(docs(`
         /*
-         * name: ${description}
+         * ${description}
          *
          * Full description
          */
@@ -321,48 +321,9 @@ ${comments.map(comment => `           * @throws ${comment}`).join('\n')}
       const description = 'Creates a user in the database';
       assert.deepEqual(docs(`
         /*
-          name: ${description}
+          ${description}
          */
       `).description, description);
-    });
-  });
-
-  describe('@name', () => {
-    it('should add a name based on the string before the description', () => {
-      assert.equal(docs(`
-        /*
-         * action: Description
-         */
-      `).name, 'action');
-    });
-
-    it('should default to name if no description', () => {
-      assert.equal(docs(`
-        /*
-         * action
-         */
-      `).name, 'action');
-    });
-
-    it('should add it with @name', () => {
-      assert.equal(docs(`
-        /*
-         * Description
-         *
-         * @name action
-         */
-      `).name, 'action');
-    });
-
-    it('should take the first @name', () => {
-      assert.equal(docs(`
-        /*
-         * Description
-         *
-         * @name action
-         * @name action1
-         */
-      `).name, 'action');
     });
   });
 
@@ -465,10 +426,10 @@ ${comments.map(comment => `           * @returns ${comment}`).join('\n')}
 
   describe('complete example', () => {
     it('should work for a full example', () => {
-      const actual = fs.readFileSync(`${__dirname}/fixtures/actual.js`);
+      const actual = fs.readFileSync(`${__dirname}/fixtures/createUser.js`);
       const expected = fs.readFileSync(`${__dirname}/fixtures/expected.json`);
 
-      assert.deepEqual(`${JSON.stringify(docs(actual), null, 2)}\n`, expected.toString());
+      assert.deepEqual(`${JSON.stringify(docs(actual, 'createUser'), null, 2)}\n`, expected.toString());
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,19 +66,19 @@ describe('build-docs', () => {
       const fullDescription = 'Creates a user in the database';
       assert.equal(docs(`
         /*
-         * name: description
+         * description
          * ${fullDescription}
          * @param {string} name Name of the user
          */
 
         /*
-         * name: description
+         * description
          *
          * ${fullDescription}
          */
 
         /*
-         * name: description
+         * description
          *
          * ${fullDescription}
          * @param {string} name Name of the user
@@ -90,7 +90,7 @@ describe('build-docs', () => {
       const multiLineFullDescription = ['line-1', 'line-2', 'line-3'];
       assert.equal(docs(`
         /*
-         * name: description
+         * description
 ${multiLineFullDescription.map(desc => `           * ${desc}`).join('\n')}
          * @param {string} name Name of the user
          */
@@ -100,7 +100,7 @@ ${multiLineFullDescription.map(desc => `           * ${desc}`).join('\n')}
     it('should default to empty string', () => {
       assert.deepEqual(docs(`
         /*
-         * name: description
+         * description
          */
       `).fullDescription, '');
     });
@@ -118,7 +118,7 @@ ${multiLineFullDescription.map(desc => `           * ${desc}`).join('\n')}
 
       // This is sketchy... but it works
       assert.deepEqual(docs(`
-        /* name: description
+        /* description
 ${comments.map(comment => `           * @param ${comment}`).join('\n')}
          */
       `).params, expected);
@@ -127,7 +127,7 @@ ${comments.map(comment => `           * @param ${comment}`).join('\n')}
     function testInvalidType(type) {
       assert.throws(() => {
         docs(`
-        /* name: description
+        /* description
          * @param {${type}} name - name of the user
          */`);
       }, /Invalid type ".*" - Type must be: null, boolean, object, array, number, string/);
@@ -141,7 +141,7 @@ ${comments.map(comment => `           * @param ${comment}`).join('\n')}
     it('should not allow objects', () => {
       assert.throws(() => {
         docs(`
-        /* name: description
+        /* description
          * @param {object} name - name of the user
          */`);
       }, /Invalid Param - Nested objects are not supported./);
@@ -150,7 +150,7 @@ ${comments.map(comment => `           * @param ${comment}`).join('\n')}
     it('should not allow array of objects', () => {
       assert.throws(() => {
         docs(`
-        /* name: description
+        /* description
          * @param {Object[]} users - users
          * @param {string} users.name - users
          */`);
@@ -161,7 +161,7 @@ ${comments.map(comment => `           * @param ${comment}`).join('\n')}
       if (type === 'object') return assert(true);
       return assert.doesNotThrow(() => {
         docs(`
-        /* name: description
+        /* description
          * @param {${type}} name - name of the user
          */`);
       });
@@ -270,7 +270,7 @@ ${comments.map(comment => `           * @param ${comment}`).join('\n')}
 
       // This is sketchy... but it works
       assert.deepEqual(docs(`
-        /* name: description
+        /* description
 ${comments.map(comment => `           * @throws ${comment}`).join('\n')}
          */
       `).throws, expected);
@@ -335,7 +335,7 @@ ${comments.map(comment => `           * @throws ${comment}`).join('\n')}
 
       // This is sketchy... but it works
       assert.deepEqual(docs(`
-        /* name: description
+        /* description
 ${comments.map(comment => `           * @secret ${comment}`).join('\n')}
          */
       `).secrets[0], expected);
@@ -351,7 +351,7 @@ ${comments.map(comment => `           * @secret ${comment}`).join('\n')}
     it('should return an empty array if no @secret', () => {
       assert.equal(docs(`
         /*
-         * name: test
+         * test
          */
       `).secrets.length, 0);
     });
@@ -365,7 +365,7 @@ ${comments.map(comment => `           * @secret ${comment}`).join('\n')}
 
       // This is sketchy... but it works
       assert.deepEqual(docs(`
-        /* name: description
+        /* description
 ${comments.map(comment => `           * @returns ${comment}`).join('\n')}
          */
       `).returns, expected);
@@ -381,7 +381,7 @@ ${comments.map(comment => `           * @returns ${comment}`).join('\n')}
     it('should return null if no @returns', () => {
       assert.equal(String(docs(`
         /*
-         * name: test
+         * test
          */
       `).returns), 'null');
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -304,6 +304,37 @@ ${comments.map(comment => `           * @throws ${comment}`).join('\n')}
     });
   });
 
+  describe('errors', () => {
+    it('should export an object of error types and compiled template functions', () => {
+      const errors = docs([
+        '/*',
+        // eslint-disable-next-line no-template-curly-in-string
+        '* @throws {ValidationError} Will throw an ${test} error if the argument is null ${x}',
+        // eslint-disable-next-line no-template-curly-in-string
+        '* @throws {AnotherError} You cant do ${y}',
+        '*/',
+      ].join('\n')).errors;
+
+      assert.deepEqual(Object.keys(errors), ['ValidationError', 'AnotherError']);
+      assert.deepEqual(errors.ValidationError({ test: 'a', x: 'b' }),
+        'Will throw an a error if the argument is null b');
+      assert.deepEqual(errors.AnotherError({ y: 'c' }), 'You cant do c');
+    });
+
+    describe('toString()', () => {
+      it('should output source code', () => {
+        const errors = docs([
+          '/*',
+          // eslint-disable-next-line no-template-curly-in-string
+          '* @throws {ValidationError} Will throw an ${test} error if the argument is null ${x}',
+          '*/',
+        ].join('\n')).errors;
+
+        assert.equal(typeof errors.toString().ValidationError.toString(), 'string');
+      });
+    });
+  });
+
   describe('alternative comment styles', () => {
     // This style can't be supported because esprima picks each
     // line up as a new comment because technically it starts/ends

--- a/test/parse-directory.test.js
+++ b/test/parse-directory.test.js
@@ -1,0 +1,65 @@
+const os = require('os');
+const fs = require('fs');
+const assert = require('assert');
+const rimraf = require('rimraf');
+const { join } = require('path');
+
+const { parseDirectory } = require('../');
+
+let cwd;
+let tmpDir;
+
+const files = {
+  hello: {
+    description: 'Description of hello',
+  },
+  goodbye: {
+    description: 'Description of goodbye',
+  },
+};
+
+describe('parse-directory', () => {
+  beforeEach(() => {
+    cwd = process.cwd();
+
+    tmpDir = fs.mkdtempSync(`${os.tmpdir()}/`);
+
+    process.chdir(tmpDir);
+  });
+
+  beforeEach(() => {
+    Object.keys(files).forEach((file) => {
+      fs.writeFileSync(join(tmpDir, `${file}.js`), `
+        /*
+         * ${file}: ${files[file].description}
+         */
+      `);
+    });
+  });
+
+  afterEach(() => {
+    rimraf.sync(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+  });
+
+  it('should read all files and parse out comments', () => {
+    const docs = parseDirectory(tmpDir);
+
+    assert.equal(docs.length, 2);
+    assert.deepEqual(docs.map(doc => doc.name), ['goodbye', 'hello']);
+  });
+
+  it('should ignore non-js files', () => {
+    fs.writeFileSync(join(tmpDir, 'text-file.txt'), `
+      /*
+       * This shouldn't be picked up
+       */
+    `);
+
+    const docs = parseDirectory(tmpDir);
+    assert.equal(docs.length, 2);
+  });
+});


### PR DESCRIPTION
- Refactor main export to only return 1 doc per piece of source code

- Add `parseDirectory` exported function
When given a folder, it'll read all the js files and parse the first comment block out of it

- Remove the concept of name
Both from the description line and from the @name syntax

This is now going to be determined from the file name