### PR TITLE
Add support for @error

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,21 +9,21 @@ const parseSecrets = require('./lib/secrets');
 
 function getTags(parsed, t) {
   return parsed.tags
-    .filter(tag => tag.name === t)
+    .filter(tag => t.includes(tag.name))
     .map(p => p.value);
 }
 
 function parseComment(comment, name) {
-  const throws = parseThrows(getTags(comment, 'throws'));
+  const throws = parseThrows(getTags(comment, ['throws', 'error']));
   return {
     name,
     description: parseDescription(comment.lines[0]),
     fullDescription: parseFullDescription(comment.lines),
-    params: parseParams(getTags(comment, 'param')),
+    params: parseParams(getTags(comment, ['param'])),
     throws,
     errors: buildErrors(throws),
-    secrets: parseSecrets(getTags(comment, 'secret')),
-    returns: parseReturns(getTags(comment, 'returns')),
+    secrets: parseSecrets(getTags(comment, ['secret'])),
+    returns: parseReturns(getTags(comment, ['returns'])),
   };
 }
 

--- a/test/fixtures/createUser.js
+++ b/test/fixtures/createUser.js
@@ -9,6 +9,7 @@
  * @param {number} age=12 Age of the user
  * @param {string[]} interests Interests of the user
  * @throws {ValidationError} Must provide all required fields
+ * @error {ValidationError2} Must provide all required fields
  * @returns {Object} The saved user
  */
 

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -28,6 +28,10 @@
     {
       "type": "ValidationError",
       "description": "Must provide all required fields"
+    },
+    {
+      "type": "ValidationError2",
+      "description": "Must provide all required fields"
     }
   ],
   "errors": {},

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -274,6 +274,13 @@ ${comments.map(comment => `           * @param ${comment}`).join('\n')}
 ${comments.map(comment => `           * @throws ${comment}`).join('\n')}
          */
       `).throws, expected);
+
+      // Should also work with @error
+      assert.deepEqual(docs(`
+        /* description
+${comments.map(comment => `           * @error ${comment}`).join('\n')}
+         */
+      `).throws, expected);
     }
 
     it('should work with just a description', () => {


### PR DESCRIPTION
@error is the same as @throws, just a little more in line with `api.error`. We should continue supporting both, but I think it makes more sense for our examples to have @error, since it matches up with `api.error` better